### PR TITLE
disable cache dir feature of pip to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM python:3.12
+ENV PIP_NO_CACHE_DIR=off 
 
 COPY src/ .
 COPY requirements.txt .
 COPY run_docker.sh .
 
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 CMD ["./run_docker.sh"]
 


### PR DESCRIPTION
Disabling the cache dir will reduce the image size I believe by about 3GB, since the downloaded files are no longer included in the resulting image, as they are not required there.